### PR TITLE
Remove empty path segments in URL

### DIFF
--- a/lib/skyhook_home_page.dart
+++ b/lib/skyhook_home_page.dart
@@ -98,10 +98,11 @@ class _SkyhookHomePageState extends State<SkyhookHomePage> {
       return;
     }
     Uri parsedUrl = Uri.parse(url);
+    List<String> pathSegments = List.from(parsedUrl.pathSegments);
+    pathSegments.removeWhere((item) => item == '');
     // second to last
-    String webhookId =
-        parsedUrl.pathSegments.elementAt(parsedUrl.pathSegments.length - 2);
-    String webhookSecret = parsedUrl.pathSegments.last;
+    String webhookId = pathSegments.elementAt(pathSegments.length - 2);
+    String webhookSecret = pathSegments.last;
     String generatedUrl =
         "https://skyhookapi.com/api/webhooks/$webhookId/$webhookSecret/$providerPath";
 


### PR DESCRIPTION
If I put an url ending with a `/`
e.g. `https://discord.com/api/webhooks/123456789/qwertyuiop/`
I have generated
`https://skyhookapi.com/api/webhooks/qwertyuiop//gitlab` 
Expected was the url
`https://skyhookapi.com/api/webhooks/123456789/qwertyuiop/gitlab`

This MR solves the problem removing the empty paths